### PR TITLE
Add role management to AuthController

### DIFF
--- a/DocumentManagement/Controllers/AuthController.cs
+++ b/DocumentManagement/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 ﻿using DocumentManagement.Models.DTO;
 using DocumentManagement.Services.IService;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DocumentManagement.Controllers
@@ -31,6 +32,25 @@ namespace DocumentManagement.Controllers
             var result = await _authService.LoginAsync(request);
             if (!result.Success)
                 return Unauthorized(result.Message);
+
+            return Ok(result);
+        }
+
+        [Authorize]
+        [HttpPost("logout")]
+        public IActionResult Logout()
+        {
+            // We can invalidate token on client side
+            return Ok(new { Message = "Logged out successfully" });
+        }
+
+        [Authorize(Roles = "admin")]
+        [HttpPost("set-role")]
+        public async Task<IActionResult> SetUserRole([FromBody] SetUserRoleDto request)
+        {
+            var result = await _authService.SetUserRoleAsync(request);
+            if (!result.Success)
+                return BadRequest(result.Message);
 
             return Ok(result);
         }

--- a/DocumentManagement/Models/DTO/SetUserRoleDto.cs
+++ b/DocumentManagement/Models/DTO/SetUserRoleDto.cs
@@ -1,0 +1,8 @@
+﻿namespace DocumentManagement.Models.DTO
+{
+    public class SetUserRoleDto
+    {
+        public string Username { get; set; }
+        public string Role { get; set; }
+    }
+}

--- a/DocumentManagement/Services/AuthService.cs
+++ b/DocumentManagement/Services/AuthService.cs
@@ -101,6 +101,38 @@ namespace DocumentManagement.Services
             return new JwtSecurityTokenHandler().WriteToken(token);
         }
 
+        public async Task<AuthResultDto> SetUserRoleAsync(SetUserRoleDto request)
+        {
+            try
+            {
+                if (!_validRoles.Contains(request.Role.ToLower()))
+                {
+                    return new AuthResultDto { Success = false, Message = "Invalid role specified" };
+                }
+
+                var user = await _context.Users.FirstOrDefaultAsync(u => u.Username == request.Username);
+                if (user == null)
+                {
+                    return new AuthResultDto { Success = false, Message = "User not found" };
+                }
+
+                user.Role = request.Role.ToLower();
+                _context.Users.Update(user);
+                await _context.SaveChangesAsync();
+
+                return new AuthResultDto
+                {
+                    Success = true,
+                    Message = $"Role '{request.Role}' assigned to user '{request.Username}'"
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error setting user role");
+                return new AuthResultDto { Success = false, Message = "An error occurred. Please try again later." };
+            }
+        }
+
         private bool IsPasswordStrong(string password)
         {
             return password.Length >= 8 &&

--- a/DocumentManagement/Services/IService/IAuthService.cs
+++ b/DocumentManagement/Services/IService/IAuthService.cs
@@ -6,5 +6,6 @@ namespace DocumentManagement.Services.IService
     {
         Task<AuthResultDto> RegisterAsync(RegisterDto dto);
         Task<AuthResultDto> LoginAsync(LoginDto dto);
+        Task<AuthResultDto> SetUserRoleAsync(SetUserRoleDto request);
     }
 }


### PR DESCRIPTION
- Secured endpoints with `[Authorize]` and role-based access control.
- Added `Logout` and `SetUserRole` endpoints in `AuthController`.
- Introduced `SetUserRoleDto` for role assignment data handling.
- Implemented `SetUserRoleAsync` in `AuthService` for role updates.
- Updated `IAuthService` interface to include role management logic.